### PR TITLE
Update composer.json to be compatible with roots/bedrock configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "description": "Custom MyParcel Asia plugin for Woocommerce",
-    "name": "mpa/woocommerce",
+    "name": "myparcelasia/wc_myparcelasia",
     "license": "MIT",
-    "type": "project",
+    "type": "wordpress-plugin",
+    "description": "Custom MyParcel Asia plugin for Woocommerce",
     "require": {
         "wanfeiyy/dd": "^1.0",
         "vlucas/phpdotenv": "^5.4"


### PR DESCRIPTION
I would like to suggest the change of `type` to `wordpress-plugin` so that when I use this repo with composer.json based WordPress (roots/bedrock), it can be automatically installed into the right folder (plugins).

Read more here: https://github.com/roots/bedrock/blob/master/composer.json